### PR TITLE
README.md: fix build for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You will need the following libraries (and their dependencies):
 Open a terminal window, navigate to the PCem directory then enter:
 ### Linux
 ```
+autoreconf -i
 ./configure --enable-release
 make
 ```


### PR DESCRIPTION
README gives an incomplete build procedure as the `configure` file does not exist. This commit adds necessary steps to build by copying the ones from the github wiki.

I didn't modify the BSD section as I'm not sure if the same commands would work equally.

Note that since upstream changed the build system, this PR is only good at fixing this fork in its current detached state.